### PR TITLE
refresh etag on edited image

### DIFF
--- a/admin/src/components/MediaLibrary.vue
+++ b/admin/src/components/MediaLibrary.vue
@@ -247,6 +247,7 @@ export default {
     closeEditor() {
       this.editor = false
       this.editUrl = null
+      this.getMediaLibrary()
     },
     addTag() {
       this.tags.push('')


### PR DESCRIPTION
Should fix #13. Added another call to getMediaLibrary() to refresh the etag on an edited image, so you can now edit an image and then immediately delete it without the request erroring out.