### PR TITLE
Add python3 support

### DIFF
--- a/mir/ansible/roles/api/templates/settings.py
+++ b/mir/ansible/roles/api/templates/settings.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 
 # -----------------------------------

--- a/mir/cli.py
+++ b/mir/cli.py
@@ -2,6 +2,7 @@
 
 """Console script for mir."""
 
+from __future__ import absolute_import
 import os
 import re
 import shutil
@@ -9,7 +10,7 @@ import shutil
 import click
 import requests
 
-from utilities import run_call, generate_password, generate_secret_key
+from .utilities import run_call, generate_password, generate_secret_key
 
 templates_path = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), 'templates'
@@ -34,7 +35,7 @@ def main(args=None):
 @main.command()
 @click.argument('name')
 def init(name):
-    from lib.templating import template_factory
+    from .lib.templating import template_factory
 
     name = validate_name(None, None, name)
 
@@ -115,13 +116,13 @@ def init(name):
 @main.command()
 @click.option('--port', '-p', default='8080')
 def start(port):
-    from mir import start_app
+    from .mir import start_app
     start_app(port=port)
 
 @main.command()
 @click.option('--port', '-p', default='8080')
 def dev(port):
-    from mir import start_app
+    from .mir import start_app
     start_app(reload=True, port=port)
 
 
@@ -135,7 +136,7 @@ def dev(port):
 @click.option('--example', '-e', is_flag=True, default=False)
 @click.option('--url', '-u')
 def model(name, example, url):
-    from config import APP_DIR
+    from .config import APP_DIR
 
     out_dir = os.path.join(APP_DIR, 'models')
     if not example:
@@ -144,7 +145,7 @@ def model(name, example, url):
             with open(os.path.join(out_dir, '%s.py' % name), 'w') as f:
                 f.write(r.text)
         else:
-            from lib.templating import template_factory
+            from .lib.templating import template_factory
             data = {
                 'name': name,
             }
@@ -169,7 +170,7 @@ def model(name, example, url):
 )
 @click.option('--url', '-u')
 def route(name, url):
-    from config import APP_DIR
+    from .config import APP_DIR
 
     out_dir = os.path.join(APP_DIR, 'routes')
 
@@ -178,7 +179,7 @@ def route(name, url):
         with open(os.path.join(out_dir, '%s.py' % name), 'w') as f:
             f.write(r.text)
     else:
-        from lib.templating import template_factory
+        from .lib.templating import template_factory
         data = {
             'name': name,
         }
@@ -216,7 +217,7 @@ def route(name, url):
 )
 @click.option('--url', '-u')
 def hook(name, timing, method, resource, url):
-    from config import APP_DIR
+    from .config import APP_DIR
 
     out_dir = os.path.join(APP_DIR, 'hooks')
 
@@ -226,7 +227,7 @@ def hook(name, timing, method, resource, url):
         with open(os.path.join(out_dir, '%s.py' % name), 'w') as f:
             f.write(r.text)
     else:
-        from lib.templating import template_factory
+        from .lib.templating import template_factory
 
         def validate_timing(value):
             if value == 'pre' or value == 'post':
@@ -259,7 +260,7 @@ def hook(name, timing, method, resource, url):
 @main.command()
 @click.argument('environment')
 def deploy(environment):
-    from config import ROOT_DIR, APP_DIR
+    from .config import ROOT_DIR, APP_DIR
 
     if environment == 'local':
         click.echo(click.style('\n[-] Deploying to the local environment\n', bold=True, fg='white'), err=False)

--- a/mir/config.py
+++ b/mir/config.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 import json
+from six.moves import range
 
 
 def find_root():
     working_dir = os.getcwd().split(os.sep)
     length = len(working_dir) + 1
-    build_paths = filter(lambda x: x != '', ['/'.join(working_dir[:x]) for x in range(length)])
+    build_paths = [x for x in ['/'.join(working_dir[:x]) for x in range(length)] if x != '']
     paths = [x for x in reversed(build_paths)]
     for path in paths:
         test_root = os.path.join(path, '.mir')

--- a/mir/lib/__init__.py
+++ b/mir/lib/__init__.py
@@ -1,1 +1,2 @@
-import default_models
+from __future__ import absolute_import
+from . import default_models

--- a/mir/lib/blueprints.py
+++ b/mir/lib/blueprints.py
@@ -3,6 +3,7 @@
 A factory for registering all blueprints as custom endpoints from the routes directory.
 """
 
+from __future__ import absolute_import
 import os
 import io
 import csv
@@ -27,6 +28,7 @@ from mir.lib.common import get_attribute_names
 from mir.lib.images import init_image_manipulation_api
 from mir.lib.templating import template_factory
 from mir.config import APP_DIR, HAS_PROJECT_ROOT
+import six
 # Add additional default routes manually
 
 admin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'admin')
@@ -60,7 +62,7 @@ def blueprint_factory(app):
         authorized = app.auth.check_auth(token, None, None, "POST")
         domain = app.config.get('DOMAIN')
         schema = domain.get(resource, {})
-        fieldnames = schema.get('schema', {}).keys()
+        fieldnames = list(schema.get('schema', {}).keys())
 
         if not authorized:
             status_code = 400
@@ -90,12 +92,12 @@ def blueprint_factory(app):
             for item in results:
                 item.pop('_links', None)
             csvfile = io.BytesIO()
-            writer = csv.DictWriter(csvfile, fieldnames=list(set(results[0].keys() + fieldnames)))
+            writer = csv.DictWriter(csvfile, fieldnames=list(set(list(results[0].keys()) + fieldnames)))
             writer.writeheader()
             for item in results:
                 writer.writerow({
-                    k: v.encode('ascii', 'ignore') if isinstance(v, basestring) else v
-                    for k, v in item.iteritems()
+                    k: v.encode('ascii', 'ignore') if isinstance(v, six.string_types) else v
+                    for k, v in six.iteritems(item)
                 })
             csvfile.seek(0)
             return send_file(csvfile, attachment_filename="export.csv")

--- a/mir/lib/bootstrap.py
+++ b/mir/lib/bootstrap.py
@@ -3,6 +3,7 @@
 Application bootstrap functions
 """
 
+from __future__ import absolute_import
 import bcrypt
 
 

--- a/mir/lib/common.py
+++ b/mir/lib/common.py
@@ -4,6 +4,7 @@
 Shared application utility functions.
 """
 
+from __future__ import absolute_import
 import os
 import importlib
 from base64 import b64encode
@@ -13,6 +14,7 @@ import bcrypt
 from flask import current_app as app
 
 from mir.config import APP_DIR, HAS_PROJECT_ROOT
+import six
 
 # -----------------------------------
 # Factory Meta Programming Helpers
@@ -88,7 +90,7 @@ def get_models():
     def process_auth(v):
         auth = {}
         for key, value in v.items():
-            if key == 'authentication' and isinstance(value, basestring):
+            if key == 'authentication' and isinstance(value, six.string_types):
                 v[key] = auth[value]
         return v
 
@@ -106,7 +108,7 @@ def get_models():
     def create_domain(all_models):
         return {
             k: process_auth(v)
-            for d in filter(lambda x: x, all_models)
+            for d in [x for x in all_models if x]
             for k, v in d.items()
         }
 

--- a/mir/lib/default_models/__init__.py
+++ b/mir/lib/default_models/__init__.py
@@ -1,4 +1,5 @@
-import accounts
-import log
-import sitemedia
-import users
+from __future__ import absolute_import
+from . import accounts
+from . import log
+from . import sitemedia
+from . import users

--- a/mir/lib/filestore.py
+++ b/mir/lib/filestore.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 import time
 
 from datetime import datetime

--- a/mir/lib/hooks.py
+++ b/mir/lib/hooks.py
@@ -3,6 +3,7 @@
 A factory for registering all custom hooks from the hooks directory.
 """
 
+from __future__ import absolute_import
 import os
 import json
 import importlib

--- a/mir/lib/image_processing/factory.py
+++ b/mir/lib/image_processing/factory.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import io
 
 from PIL import Image

--- a/mir/lib/image_processing/transformations.py
+++ b/mir/lib/image_processing/transformations.py
@@ -1,4 +1,6 @@
+from __future__ import absolute_import
 from PIL import Image, ImageFilter, ImageEnhance, ImageOps, ImageDraw
+from six.moves import range
 
 # ---------------------------------
 # Transformation Functions

--- a/mir/lib/images.py
+++ b/mir/lib/images.py
@@ -1,5 +1,5 @@
+from __future__ import absolute_import
 import io
-import StringIO
 import base64
 import json
 
@@ -13,6 +13,7 @@ from eve.methods import getitem
 from mir.lib.image_processing.transformations import funcs
 from mir.lib.image_processing.factory import process
 from mir.lib.image_processing.validation import schema
+import six
 
 
 v = Validator()
@@ -69,7 +70,7 @@ def init_image_manipulation_api(app):
                     format=instructions.get(
                         'format',
                         get_format_for_content_type(content_type)
-                            if 'dotpattern' not in instructions.keys()
+                            if 'dotpattern' not in list(instructions.keys())
                             else 'PNG'
                     ),
                     quality=instructions.get('quality', 95)
@@ -77,7 +78,7 @@ def init_image_manipulation_api(app):
 
                 # Run Process Actions
                 output = processor([
-                    funcs[key](value) for key, value in instructions.iteritems() \
+                    funcs[key](value) for key, value in six.iteritems(instructions) \
                     if funcs.get(key, False)
                 ])
 
@@ -123,7 +124,7 @@ def init_image_manipulation_api(app):
 
                 # Run Process Actions
                 output = processor([
-                    funcs[key](value) for key, value in instructions.iteritems() \
+                    funcs[key](value) for key, value in six.iteritems(instructions) \
                     if funcs.get(key, False)
                 ])
 

--- a/mir/lib/templating.py
+++ b/mir/lib/templating.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import json
 import sys

--- a/mir/mir.py
+++ b/mir/mir.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 
+from __future__ import absolute_import
 import os
 import sys
 import multiprocessing
@@ -21,12 +22,12 @@ from eve.io.mongo.media import GridFSMediaStorage
 from flask import request, current_app as app
 from flask_cors import CORS
 
-from lib.common import get_settings_dict, get_models
-from lib.hooks import hooks_factory
-from lib.blueprints import blueprint_factory
-from lib.bootstrap import create_admin
+from .lib.common import get_settings_dict, get_models
+from .lib.hooks import hooks_factory
+from .lib.blueprints import blueprint_factory
+from .lib.bootstrap import create_admin
 
-from config import APP_DIR
+from .config import APP_DIR
 
 
 # ------------------------------

--- a/mir/templates/settings.py
+++ b/mir/templates/settings.py
@@ -4,6 +4,7 @@
 # Documentation coming soon
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+from __future__ import absolute_import
 import os
 
 # Optional AWS Storage

--- a/mir/utilities.py
+++ b/mir/utilities.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 import copy
 import json
 import string
 import binascii
 from subprocess import call, Popen, check_call, check_output, STDOUT
+import six
 
 FNULL = open(os.devnull, 'w')
 
@@ -64,7 +66,7 @@ def remove_read_only(v):
 
 def translations(model, languages=None):
     schema = model['schema']
-    nested = { k: remove_read_only(v) for k, v in copy.deepcopy(schema).iteritems() }
+    nested = { k: remove_read_only(v) for k, v in six.iteritems(copy.deepcopy(schema)) }
     if nested.get('slug', False):
         nested.pop('slug')
 
@@ -102,7 +104,7 @@ def translations(model, languages=None):
             }
         }
     else:
-        for idx, (abbrev, language) in enumerate(languages.iteritems()):
+        for idx, (abbrev, language) in enumerate(six.iteritems(languages)):
             schema[abbrev] = {
                 "type": "dict",
                 "schema": nested,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,11 @@ requests
 bleach
 boto3
 flask-cors
-bucketstore
 gunicorn
-jinja2
-cloudinary
+Jinja2
 ansible
+paramiko
 gevent
 PyJWT
+Pillow
+six

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,23 @@ with open('README.md') as readme_file:
 with open('HISTORY.md') as history_file:
     history = history_file.read()
 
+def read_file(file_name):
+    """Read file and return its contents."""
+    with open(file_name, 'r') as f:
+        return f.read()
+
+def read_requirements(file_name):
+    """Read requirements file as a list."""
+    reqs = read_file(file_name).splitlines()
+    if not reqs:
+        raise RuntimeError(
+            "Unable to read requirements from the %s file"
+            "That indicates this copy of the source code is incomplete."
+            % file_name
+        )
+    return reqs
+
+"""
 requirements = [
     'ansible==2.5.0',
     'asn1crypto==0.24.0',
@@ -64,6 +81,9 @@ requirements = [
     'Pillow',
     # TODO: Put package requirements here
 ]
+"""
+
+requirements = read_requirements('requirements.txt')
 
 setup_requirements = [
     # TODO(spbrien): Put setup requirements (distutils extensions, etc.) here
@@ -101,9 +121,12 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7'
+        'Programming Language :: Python :: 2.7',
+        "Programming Language :: Python :: 3",
+        'Programming Language :: Python :: 3.6',
     ],
     test_suite='tests',
     tests_require=test_requirements,
     setup_requires=setup_requirements,
+    use_2to3=True
 )

--- a/tests/test_mir.py
+++ b/tests/test_mir.py
@@ -4,6 +4,7 @@
 """Tests for `mir` package."""
 
 
+from __future__ import absolute_import
 import unittest
 from click.testing import CliRunner
 
@@ -28,7 +29,7 @@ class TestMir(unittest.TestCase):
         runner = CliRunner()
         result = runner.invoke(cli.main)
         assert result.exit_code == 0
-        assert 'mir.cli.main' in result.output
+        assert 'Usage:' in result.output
         help_result = runner.invoke(cli.main, ['--help'])
         assert help_result.exit_code == 0
         assert '--help  Show this message and exit.' in help_result.output


### PR DESCRIPTION
I ran the package code through [Modernize](https://python-modernize.readthedocs.io/en/latest/) and audited the changes it made. Essentially, it just changed all relative imports to absolute imports, added some wrappers around iteritems and string type checks, and forced list coercion on some types that return lists in python2 and generators in python3.