### PR TITLE
Fix SSL error and include ansible peers

### DIFF
--- a/mir/cli.py
+++ b/mir/cli.py
@@ -7,6 +7,9 @@ import os
 import re
 import shutil
 
+import gevent.monkey
+gevent.monkey.patch_all()
+
 import click
 import requests
 

--- a/mir/lib/blueprints.py
+++ b/mir/lib/blueprints.py
@@ -128,7 +128,7 @@ def blueprint_factory(app):
                 valid_account = accounts.find_one(lookup)
                 valid_password = bcrypt.hashpw(
                     password.encode('utf-8'),
-                    valid_account['password'].encode('utf-8')
+                    valid_account['password']
                 ) == valid_account['password'] if valid_account else None
 
                 if valid_account and valid_password:

--- a/mir/mir.py
+++ b/mir/mir.py
@@ -8,6 +8,10 @@ from __future__ import absolute_import
 import os
 import sys
 import multiprocessing
+
+import gevent.monkey
+gevent.monkey.patch_all()
+
 import gunicorn.app.base
 from gunicorn.six import iteritems
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ gevent
 PyJWT
 Pillow
 six
+PyYAML


### PR DESCRIPTION
I didn't encounter this until I tried to use the requests module in a model, but in 3.6+, unless it can patch it first, gevent causes a `RecursionError` when other modules try to use SSL.

I also received an error when trying to log in through basic auth because there was a line in lib/blueprints.py that was trying to encode the password from utf8 to bytes, but it's already bytes coming out of the database.

Finally, ansible needs pyyaml, but it wasn't included on install, so I added it to requirements.txt